### PR TITLE
Added a See-More section

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,6 +434,19 @@ A handy bonefide checklist that to see how your README is doing:
 - [ ] Doesn't rely on images to relay critical information
 - [ ] License
 
+## Bonus: See more
+
+This work, like all code, was inspired by lots of community efforts (and
+not just the Perl monks), and arose out of many conversations and other efforts.
+Here are a few other resources that come from similar places:
+
+ - [A long, interesting GitHub conversation](https://github.com/feross/standard/issues/141)
+ about making good READMEs and standardizing them
+ - [@richardlitt's standard-readme](https://github.com/RichardLitt/readme-standard),
+ based on the above, which has a specification for what a README should look like,
+ and a generator and proposed linter
+ - [zwei/standard-readme](https://github.com/zcei/standard-readme) - Another early
+ resource for javascript Readme standardization
 
 ## Call to arms!
 


### PR DESCRIPTION
Taken mainly from common-readme. Not sure how you want to word this. I think standard-readme is the only resource here that is something at the moment; might be OK to link just that? 
